### PR TITLE
feat(courses): implement Course model and CRUD API endpoints

### DIFF
--- a/unibackend/courses/admin.py
+++ b/unibackend/courses/admin.py
@@ -1,3 +1,9 @@
 from django.contrib import admin
+from .models import Course
 
-# Register your models here.
+
+@admin.register(Course)
+class CourseAdmin(admin.ModelAdmin):
+    list_display = ("course_code", "course_name", "department", "year")
+    search_fields = ("course_code", "course_name", "department")
+    list_filter = ("department", "year")

--- a/unibackend/courses/models.py
+++ b/unibackend/courses/models.py
@@ -1,3 +1,12 @@
 from django.db import models
 
-# Create your models here.
+
+class Course(models.Model):
+    course_code = models.CharField(max_length=50, unique=True)
+    course_name = models.CharField(max_length=255)
+    department = models.CharField(max_length=255)
+    year = models.PositiveSmallIntegerField()
+    description = models.TextField()
+
+    def __str__(self):
+        return f"{self.course_code} - {self.course_name}"

--- a/unibackend/courses/serializers.py
+++ b/unibackend/courses/serializers.py
@@ -1,0 +1,8 @@
+from rest_framework import serializers
+from .models import Course
+
+
+class CourseSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Course
+        fields = ["id", "course_code", "course_name", "department", "year", "description"]

--- a/unibackend/courses/urls.py
+++ b/unibackend/courses/urls.py
@@ -1,0 +1,8 @@
+from django.urls import path
+from .views import CourseListCreateView, CourseDetailView
+
+
+urlpatterns = [
+    path("", CourseListCreateView.as_view(), name="course-list-create"),
+    path("<int:pk>/", CourseDetailView.as_view(), name="course-detail"),
+]

--- a/unibackend/courses/views.py
+++ b/unibackend/courses/views.py
@@ -1,3 +1,26 @@
-from django.shortcuts import render
+from rest_framework import generics, permissions
+from .models import Course
+from .serializers import CourseSerializer
 
-# Create your views here.
+
+class CourseListCreateView(generics.ListCreateAPIView):
+    serializer_class = CourseSerializer
+    permission_classes = [permissions.AllowAny]
+
+    def get_queryset(self):
+        queryset = Course.objects.all()
+        department = self.request.query_params.get("department")
+        year = self.request.query_params.get("year")
+
+        if department:
+            queryset = queryset.filter(department__iexact=department)
+        if year:
+            queryset = queryset.filter(year=year)
+
+        return queryset
+
+
+class CourseDetailView(generics.RetrieveUpdateDestroyAPIView):
+    queryset = Course.objects.all()
+    serializer_class = CourseSerializer
+    permission_classes = [permissions.AllowAny]

--- a/unibackend/root/urls.py
+++ b/unibackend/root/urls.py
@@ -20,4 +20,5 @@ from django.urls import path, include
 urlpatterns = [
     path('admin/', admin.site.urls),
     path("api/accounts/", include("accounts.urls")),
+    path("api/courses/", include("courses.urls")),
 ]


### PR DESCRIPTION
## Summary
Implemented Courses module backend with full CRUD API and routing.

## Changes
- Added `Course` model (`course_code`, `course_name`, `department`, `year`, `description`)
- Added admin registration for `Course`
- Added `CourseSerializer`
- Added endpoints:
  - `GET/POST /api/courses/`
  - `GET/PUT/DELETE /api/courses/{id}/`
- Added filtering on list endpoint: `department`, `year`
- Wired routes in root urls
- Added migrations

## Validation
- Manually tested create, list, retrieve, update, delete
- Verified filter queries work

closes #13 
